### PR TITLE
Move to bitnamilegacy

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.2
+version: 2.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -8,6 +8,8 @@ service:
     tag: "v0.50.15"
 
 global:
+  security:
+    allowInsecureImages: true
   postgresql:
     auth:
       username: "admin"
@@ -18,6 +20,7 @@ global:
 postgresql:
   image:
     tag: "12"
+    repository: "bitnamilegacy/postgresql"
   fullnameOverride: "metabase-db"
 
 security:

--- a/charts/redash/Chart.yaml
+++ b/charts/redash/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.7
+version: 0.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/redash/Chart.yaml
+++ b/charts/redash/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.8
+version: 0.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/redash/values.yaml
+++ b/charts/redash/values.yaml
@@ -39,6 +39,8 @@ redash:
   postgresql:
     enabled: false
     existingSecret: toto
-
+  redis:
+    image:
+      repository: bitnamilegacy/redis
 userPreferences:
   language: "en"

--- a/charts/redash/values.yaml
+++ b/charts/redash/values.yaml
@@ -1,4 +1,6 @@
 global:
+  security:
+    allowInsecureImages: true
   postgresql:
     auth:
       username: "admin"
@@ -8,6 +10,7 @@ global:
 postgresql:
   image:
     tag: "12"
+    repository: "bitnamilegacy/postgresql"
   fullnameOverride: "redash-db"
 
 ingress:

--- a/charts/superset/Chart.yaml
+++ b/charts/superset/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.11
+version: 0.1.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/superset/values.yaml
+++ b/charts/superset/values.yaml
@@ -1,3 +1,6 @@
+global:
+  security:
+    allowInsecureImages: true
 superset:
   init:
     adminUser:
@@ -70,7 +73,13 @@ superset:
       db_host: superset-db
 
   postgresql:
+    image:
+      repository: bitnamilegacy/postgresql
     fullnameOverride: "superset-db"
+
+  redis:
+    image:
+      repository: bitnamilegacy/redis
 
 ingress:
   enabled: false


### PR DESCRIPTION
Due to the latest changes from Bitnami, we are moving our dependency from the bitnami repository to bitnamilegacy.
This is a temporary solution, as the bitnamilegacy repository will no longer receive updates or new images.

For additional context, see https://github.com/bitnami/charts/issues/35164